### PR TITLE
XOR-321(FIX) when saving list item by swiping to right and Swipe menu…

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -199,7 +199,8 @@ function init() {
       hammer.on('swipeleft', function() {
         goToNextScreens();
       });
-      hammer.on('swiperight', function() {
+      hammer.on('swiperight', function(event) {
+        event.stopPropagation();
         goToPrevScreen();
       });
 


### PR DESCRIPTION
### Product areas affected

Menu Options -> Menu Style -> Swipe Menu

List(no images) widget -> add items -> Swipe to Save -> Yes

### What does this PR do?

Implemented fix so that in Simple list while swiping item to right jumping to previous screen issue resolved when Swipe menu option is selected

### JIRA ticket

[JIRA](https://weboo.atlassian.net/browse/XOR-321)

### Result

https://user-images.githubusercontent.com/108272606/181188469-0bdec322-755a-4993-afcd-2f7c420cea06.mp4

### Checklist

none

### Testing instructions

none

### Deployment instructions

none

### Author concerns

none