### PR TITLE
PS-1641 [FIX] Hide bottom menu when native keyboard opened

### DIFF
--- a/css/menu.css
+++ b/css/menu.css
@@ -39,6 +39,16 @@
   z-index: 10;
 }
 
+/* Hide sequential menu when keyboard is visible on native devices */
+body.fl-sequential-keyboard-visible [data-fl-widget-instance][data-type="menu"] {
+  display: none;
+}
+
+body.fl-sequential-keyboard-visible .fl-viewport-header,
+body.fl-sequential-keyboard-visible .fl-viewport-menu {
+  display: none;
+}
+
 .fl-viewport-header {
   display: flex;
   justify-content: center;

--- a/js/menu.js
+++ b/js/menu.js
@@ -11,11 +11,7 @@ var menuInstanceId = $menuElement.data('id');
  * @returns {void}
  */
 function attachKeyboardHandlers() {
-  if (!Fliplet.Env.is('native')) {
-    return;
-  }
-
-  if (!window.visualViewport) {
+  if (!Fliplet.Env.is('native') || !window.visualViewport) {
     return;
   }
 

--- a/js/menu.js
+++ b/js/menu.js
@@ -15,37 +15,39 @@ function attachKeyboardHandlers() {
     return;
   }
 
+  if (!window.visualViewport) {
+    return;
+  }
+
   var $body = $('body');
   var isKeyboardVisible = false;
-  var initialViewportHeight = window.visualViewport ? window.visualViewport.height : window.innerHeight;
+  var initialViewportHeight = window.visualViewport.height;
 
-  if (window.visualViewport) {
-    /**
-     * Handles viewport resize and scroll events to detect keyboard visibility
-     * @private
-     */
-    var viewportHandler = function() {
-      var viewportHeight = window.visualViewport.height;
+  /**
+   * Handles viewport resize and scroll events to detect keyboard visibility
+   * @private
+   */
+  var viewportHandler = function() {
+    var viewportHeight = window.visualViewport.height;
 
-      // If viewport height is significantly smaller than initial height, keyboard is visible
-      // Threshold of 150px accounts for device variations
-      var heightDifference = initialViewportHeight - viewportHeight;
-      var keyboardVisible = heightDifference > 150;
+    // If viewport height is significantly smaller than initial height, keyboard is visible
+    // Threshold of 150px accounts for device variations
+    var heightDifference = initialViewportHeight - viewportHeight;
+    var keyboardVisible = heightDifference > 150;
 
-      if (keyboardVisible && !isKeyboardVisible) {
-        isKeyboardVisible = true;
-        $body.addClass('fl-sequential-keyboard-visible');
-      } else if (!keyboardVisible && isKeyboardVisible) {
-        isKeyboardVisible = false;
-        $body.removeClass('fl-sequential-keyboard-visible');
-        // Update initial height when keyboard is fully hidden
-        initialViewportHeight = viewportHeight;
-      }
-    };
+    if (keyboardVisible && !isKeyboardVisible) {
+      isKeyboardVisible = true;
+      $body.addClass('fl-sequential-keyboard-visible');
+    } else if (!keyboardVisible && isKeyboardVisible) {
+      isKeyboardVisible = false;
+      $body.removeClass('fl-sequential-keyboard-visible');
+      // Update initial height when keyboard is fully hidden
+      initialViewportHeight = viewportHeight;
+    }
+  };
 
-    window.visualViewport.addEventListener('resize', viewportHandler);
-    window.visualViewport.addEventListener('scroll', viewportHandler);
-  }
+  window.visualViewport.addEventListener('resize', viewportHandler);
+  window.visualViewport.addEventListener('scroll', viewportHandler);
 }
 
 if (menuInstanceId) {

--- a/js/menu.js
+++ b/js/menu.js
@@ -1,11 +1,60 @@
 var $menuElement = $('[data-name="Swipe"]');
 var menuInstanceId = $menuElement.data('id');
 
+/**
+ * Attaches keyboard visibility handlers to hide the sequential menu when keyboard appears on native devices
+ *
+ * This function uses the Visual Viewport API to detect when the native keyboard is shown or hidden.
+ * When the keyboard is visible, it adds the 'fl-sequential-keyboard-visible' class to the body element,
+ * which triggers CSS rules to hide the sequential menu (both bar and navigation controls).
+ *
+ * @returns {void}
+ */
+function attachKeyboardHandlers() {
+  if (!Fliplet.Env.is('native')) {
+    return;
+  }
+
+  var $body = $('body');
+  var isKeyboardVisible = false;
+  var initialViewportHeight = window.visualViewport ? window.visualViewport.height : window.innerHeight;
+
+  if (window.visualViewport) {
+    /**
+     * Handles viewport resize and scroll events to detect keyboard visibility
+     * @private
+     */
+    var viewportHandler = function() {
+      var viewportHeight = window.visualViewport.height;
+
+      // If viewport height is significantly smaller than initial height, keyboard is visible
+      // Threshold of 150px accounts for device variations
+      var heightDifference = initialViewportHeight - viewportHeight;
+      var keyboardVisible = heightDifference > 150;
+
+      if (keyboardVisible && !isKeyboardVisible) {
+        isKeyboardVisible = true;
+        $body.addClass('fl-sequential-keyboard-visible');
+      } else if (!keyboardVisible && isKeyboardVisible) {
+        isKeyboardVisible = false;
+        $body.removeClass('fl-sequential-keyboard-visible');
+        // Update initial height when keyboard is fully hidden
+        initialViewportHeight = viewportHeight;
+      }
+    };
+
+    window.visualViewport.addEventListener('resize', viewportHandler);
+    window.visualViewport.addEventListener('scroll', viewportHandler);
+  }
+}
+
 if (menuInstanceId) {
   init();
 }
 
 function init() {
+  attachKeyboardHandlers();
+
   var data = Fliplet.Widget.getData(menuInstanceId) || {};
   var deviceWidth = $('body').width();
   var tabletBreakPoint = 640;


### PR DESCRIPTION
### Product areas affected

Menu -> Swipe

### What does this PR do?

This PR implements Visual Viewport API-based keyboard detection that automatically hides bottom menus when the keyboard is shown on native devices, and restores them when the keyboard is dismissed.

### JIRA ticket

[PS-1641](https://weboo.atlassian.net/browse/PS-1641)

[PS-1641]: https://weboo.atlassian.net/browse/PS-1641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ