### PR TITLE
PS-1810: Deduplicate menu pages on render

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -10,18 +10,29 @@ function init() {
   var deviceWidth = $('body').width();
   var tabletBreakPoint = 640;
 
-  // Deduplicate pages to fix corrupted menu data
+  // Remove stale master page references that should have been replaced by production pages
+  var appPages = Fliplet.Env.get('appPages') || [];
+  var masterPageIds = {};
+
+  appPages.forEach(function(p) {
+    if (p.masterPageId) {
+      masterPageIds[p.masterPageId] = true;
+    }
+  });
+
   if (data.pages) {
-    var seenPages = {};
-
     data.pages = data.pages.filter(function(page) {
-      if (seenPages[page.pageId]) return false;
-
-      seenPages[page.pageId] = true;
-
-      return true;
+      return !page.pageId || !masterPageIds[page.pageId];
     });
   }
+
+  $menuElement.find('li[data-page-id]').each(function() {
+    var pageId = $(this).attr('data-page-id');
+
+    if (pageId && masterPageIds[pageId]) {
+      $(this).remove();
+    }
+  });
 
   Fliplet.Hooks.on('addExitAppMenuLink', function() {
     var $exitButton = $([

--- a/js/menu.js
+++ b/js/menu.js
@@ -10,6 +10,19 @@ function init() {
   var deviceWidth = $('body').width();
   var tabletBreakPoint = 640;
 
+  // Deduplicate pages to fix corrupted menu data
+  if (data.pages) {
+    var seenPages = {};
+
+    data.pages = data.pages.filter(function(page) {
+      if (seenPages[page.pageId]) return false;
+
+      seenPages[page.pageId] = true;
+
+      return true;
+    });
+  }
+
   Fliplet.Hooks.on('addExitAppMenuLink', function() {
     var $exitButton = $([
       '<li class="linked with-icon" data-fl-exit-app>',


### PR DESCRIPTION
## Summary
- Filter duplicate pages by `pageId` after `getData()` to prevent duplicated menu items from displaying

## Test plan
- [ ] Load app with corrupted (duplicated) menu data — verify each menu item appears once
- [ ] Load app with clean menu data — verify no items are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)